### PR TITLE
Bring back SlidingGuides and cycleButtonRadius, the ability to switch…

### DIFF
--- a/lib/app_data.dart
+++ b/lib/app_data.dart
@@ -48,6 +48,9 @@ abstract class AppData extends ChangeNotifier {
   /// Whether [BoxedContainer] draws bounding boxes or not.
   bool drawLayoutBounds = true;
 
+  /// Whether [ButtonArray] includes [SlidingGuides] or not.
+  bool drawSlidingGuides = true;
+
   /// Represents whether init has completed or not.
   bool initComplete = false;
 

--- a/lib/app_data_service.dart
+++ b/lib/app_data_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:kar_kam/app_data.dart';
 import 'package:kar_kam/lib/get_it_service.dart';
 import 'package:kar_kam/lib/rect_extension.dart';
+import 'package:kar_kam/lib/map_extension.dart';
 
 /// Implements a Shared Preferences method for accessing stored app data.
 class AppDataService extends AppData {
@@ -37,7 +38,7 @@ class AppDataService extends AppData {
       'basePageViewRect': (Rect newValue) => basePageViewRect = newValue,
       'buttonAlignment': (newValue) => cycleButtonAlignment(),
       'buttonAxis': (newValue) => toggleButtonAxis(),
-      // 'buttonRadius': (newValue) => cycleButtonRadius(),
+      'buttonRadius': (newValue) => cycleButtonRadius(),
       'drawLayoutBounds': (newValue) => toggleDrawLayoutBounds(),
       'settingsPageListTileFadeEffect': (newValue) =>
           toggleSettingsPageListTileFadeEffect(),
@@ -68,16 +69,33 @@ class AppDataService extends AppData {
     buttonArrayRect = setButtonArrayRect();
   }
 
+  void cycleButtonRadius() {
+    // Define a map which can convert an integer to a double that represents
+    // a value for [buttonRadius].
+    Map<int, double> map = {
+      0: 28.0,
+      1: 32.0,
+      2: 36.0,
+      3: 24.0,
+    };
+
+    // Use [map], its inverse and the modulus operator to cycle [buttonRadius].
+    int buttonRadiusIntRepresentation = map.inverse()[buttonRadius]!;
+    buttonRadius = map[(buttonRadiusIntRepresentation + 1) % map.length]!;
+
+    // Update dependencies: [buttonArrayRect] and [buttonCoordinates].
+    buttonArrayRect = setButtonArrayRect();
+    buttonCoordinates = setButtonCoordinates();
+  }
+
   /// Initiates field variables; only called once after app start.
   @override
   void init() {
     // Exit if init has already been executed.
     if (initComplete) return;
 
-    // Calculate and upload [buttonArrayRect].
+    // Calculate and upload [buttonArrayRect] and [buttonCoordinates].
     buttonArrayRect = setButtonArrayRect();
-
-    // Calculate and upload [buttonCoordinates].
     buttonCoordinates = setButtonCoordinates();
 
     // Register that init has completed.

--- a/lib/button_array.dart
+++ b/lib/button_array.dart
@@ -3,10 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:get_it_mixin/get_it_mixin.dart';
 
 // Import project-specific files.
+import 'package:kar_kam/app_data.dart';
 import 'package:kar_kam/button.dart';
 import 'package:kar_kam/button_specs.dart';
 import 'package:kar_kam/lib/get_it_service.dart';
-import 'package:kar_kam/app_data.dart';
+import 'package:kar_kam/sliding_guides.dart';
 
 /// Implements a linear horizontal or vertical array of Buttons.
 class ButtonArray extends StatelessWidget with GetItMixin {
@@ -78,6 +79,11 @@ class ButtonArray extends StatelessWidget with GetItMixin {
         ));
       }
     }
+
+    if (GetItService.instance<AppData>().drawSlidingGuides) {
+      buttonList.add(SlidingGuides());
+    }
+
 
     // Need to return a single Widget and so return an instance of [Stack]
     // with its children defined to be a list of buttons.

--- a/lib/lib/map_extension.dart
+++ b/lib/lib/map_extension.dart
@@ -1,0 +1,5 @@
+extension MapExtension on Map {
+  Map inverse() {
+   return map((key, value) => MapEntry(value, key));
+  }
+}

--- a/lib/settings_page_list_tile.dart
+++ b/lib/settings_page_list_tile.dart
@@ -103,8 +103,9 @@ class SettingsPageListTile extends StatelessWidget with GetItMixin {
   double pathRadius = 0.0;
 
   // A temporary double for determining the slope of the connecting
-  // straight line segment that tilesnfollow as they pass around ButtonArray.
-  static double get sf => 1.125;
+  // straight line segment that tiles follow as they pass around [ButtonArray].
+  // static double get sf => 1.125;
+  static double get sf => 1.0625;
 
   /// The construction [Rect] that overlaps with [guestRect.topLeft] and
   /// [guestRect.topRight] and has the same width as [guestRect].

--- a/lib/sliding_guides.dart
+++ b/lib/sliding_guides.dart
@@ -1,0 +1,166 @@
+// Import flutter packages.
+import 'package:flutter/material.dart';
+import 'package:get_it_mixin/get_it_mixin.dart';
+import 'package:kar_kam/button_array.dart';
+import 'package:kar_kam/app_data.dart';
+import 'package:kar_kam/settings_page_list_tile.dart';
+
+/// Implements sliding guides - guide circles which indicate the path followed
+/// by [SettingsPageListTile] corners as they slide past [ButtonArray].
+class SlidingGuides extends StatelessWidget with GetItMixin {
+  SlidingGuides({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // Get [AppData] registered with [GetIt].
+    // AppData appData = GetItService.instance<AppData>();
+
+    // Watch for changes to [AppData.buttonAxis] registered with GetIt.
+    Axis buttonAxis = watchOnly((AppData a) => a.buttonAxis);
+
+    // Watch for changes to [AppData.buttonAlignment] registered with GetIt.
+    Alignment buttonAlignment = watchOnly((AppData a) => a.buttonAlignment);
+
+    // Watch for changes to [AppData.buttonRadius] registered with GetIt.
+    double buttonRadius = watchOnly((AppData a) => a.buttonRadius);
+
+    // Watch for changes to [AppData.buttonRadius] registered with GetIt.
+    double buttonPaddingMainAxis = watchOnly((AppData a) => a.buttonPaddingMainAxis);
+
+    return Stack(
+      children: [
+        // Add two additional guidance circles for checking the sliding
+        // motion of [SettingsPageListTile].
+        // ToDo: delete these unnecessary guidance circles at some point.
+        (buttonAxis == Axis.horizontal) ? Positioned(
+          top: (buttonAlignment.y < 0) ? 0 : null,
+          bottom: (buttonAlignment.y > 0) ? 0 : null,
+          left: (buttonAlignment.x < 0)
+              ? ButtonArray.buttonCoordinates!.first
+              : null,
+          right: (buttonAlignment.x > 0)
+              ? ButtonArray.buttonCoordinates!.first
+              : null,
+          child: CustomPaint(
+            painter: OpenPainter(
+              alignment: buttonAlignment,
+              axis: buttonAxis,
+              radius: buttonRadius + buttonPaddingMainAxis,
+              shiftVal: ButtonArray.rect!.shortestSide *
+                  SettingsPageListTile.sf,
+            ),
+          ),
+        ) : Positioned(
+          top: (buttonAlignment.y < 0)
+              ? ButtonArray.buttonCoordinates!.last
+              : null,
+          bottom: (buttonAlignment.y > 0)
+              ? ButtonArray.buttonCoordinates!.last
+              : null,
+          left: (buttonAlignment.x < 0) ? 0.0 : null,
+          right: (buttonAlignment.x > 0) ? 0.0 : null,
+          child: CustomPaint(
+            painter: OpenPainter(
+              alignment: buttonAlignment,
+              axis: buttonAxis,
+              radius: buttonRadius + buttonPaddingMainAxis,
+              shiftVal: ButtonArray.rect!.shortestSide *
+                  SettingsPageListTile.sf
+            ),
+          ),
+        ),
+        (buttonAxis == Axis.horizontal) ? Positioned(
+          top: (buttonAlignment.y < 0) ? 0 : null,
+          bottom: (buttonAlignment.y > 0) ? 0 : null,
+          left: (buttonAlignment.x < 0)
+              ? ButtonArray.buttonCoordinates!.last
+              : null,
+          right: (buttonAlignment.x > 0)
+              ? ButtonArray.buttonCoordinates!.last
+              : null,
+          child: CustomPaint(
+            painter: OpenPainter(
+              alignment: buttonAlignment,
+              axis: buttonAxis,
+              radius: buttonRadius + buttonPaddingMainAxis,
+              shiftVal: 0.0,
+            ),
+          ),
+        ) : Positioned(
+          top: (buttonAlignment.y < 0)
+              ? ButtonArray.buttonCoordinates!.last
+              : null,
+          bottom: (buttonAlignment.y > 0)
+              ? ButtonArray.buttonCoordinates!.last
+              : null,
+          left: (buttonAlignment.x < 0) ? 0.0 : null,
+          right: (buttonAlignment.x > 0) ? 0.0 : null,
+          child: CustomPaint(
+            painter: OpenPainter(
+              alignment: buttonAlignment,
+              axis: buttonAxis,
+              radius: buttonRadius + buttonPaddingMainAxis,
+              shiftVal: 0.0,
+            ),
+          ),
+        ),
+      ]
+    );
+  }
+}
+
+/// A custom painter for producing the guidance circles.
+class OpenPainter extends CustomPainter{
+  OpenPainter({
+    required this.alignment,
+    required this.axis,
+    required this.radius,
+    required this.shiftVal,
+  });
+
+  final Alignment alignment;
+
+  final Axis axis;
+
+  final double shiftVal;
+
+  final double radius;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    var paint1 = Paint()
+      ..color = const Color.fromRGBO(66, 165, 245, 0.5)
+      ..style = PaintingStyle.fill;
+    if (axis == Axis.horizontal) {
+      if (alignment.y < 0 && alignment.x > 0) {
+        canvas.drawCircle(Offset(-radius, radius + shiftVal), radius, paint1);
+      }
+      if (alignment.y < 0 && alignment.x < 0) {
+        canvas.drawCircle(Offset(radius, radius + shiftVal), radius, paint1);
+      }
+      if (alignment.y > 0 && alignment.x > 0) {
+        canvas.drawCircle(Offset(-radius, -radius - shiftVal), radius, paint1);
+      }
+      if (alignment.y > 0 && alignment.x < 0) {
+        canvas.drawCircle(Offset(radius, -radius - shiftVal), radius, paint1);
+      }
+    }
+    if (axis == Axis.vertical) {
+      if (alignment.y < 0 && alignment.x > 0) {
+        canvas.drawCircle(Offset(-radius, radius + shiftVal), radius, paint1);
+      }
+      if (alignment.y < 0 && alignment.x < 0) {
+        canvas.drawCircle(Offset(radius, radius + shiftVal), radius, paint1);
+      }
+      if (alignment.y > 0 && alignment.x > 0) {
+        canvas.drawCircle(Offset(-radius, -radius - shiftVal), radius, paint1);
+      }
+      if (alignment.y > 0 && alignment.x < 0) {
+        canvas.drawCircle(Offset(radius, -radius - shiftVal), radius, paint1);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => true;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -95,10 +95,10 @@ packages:
     dependency: "direct main"
     description:
       name: get_it
-      sha256: "290fde3a86072e4b37dbb03c07bec6126f0ecc28dad403c12ffe2e5a2d751ab7"
+      sha256: f9982979e3d2f286a957c04d2c3a98f55b0f0a06ffd6c5c4abbb96f06937f463
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.3.0"
   get_it_mixin:
     dependency: "direct main"
     description:


### PR DESCRIPTION
… button radius in SettingsPageContents.

SlidingGuides is now part of ButtonArray, rather than a separate entity that is added to the instance of Stack in BasePage.

The issue in the previous version of this project, now defunct, where cycleButtonRadius caused a misalignment between SlidingGuides, ButtonArray and the movement/position of SettingsPageListTile is solved in this commit.